### PR TITLE
Enable vulnerability alerts

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -28,6 +28,9 @@
       "commitMessageTopic": "{{depName}}"
     }
   ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
   "prHourlyLimit": 20,
   "prConcurrentLimit": 1
 }


### PR DESCRIPTION
## Enabled Vulnerability Alerts

From @JslYoon's [changes](https://github.com/devfile-samples/devfile-sample-python-basic/pull/70/commits/7d040d68a1a751c6e5670d7f5e69a9ad54983a38#r2228898386) in https://github.com/devfile-samples/devfile-sample-python-basic/pull/70, we would like to enable vulnerability alerts for all onboarded repositories under the [devfile-samples](https://github.com/devfile-samples) organization.