### PR TITLE
add label to all renovate prs

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -32,5 +32,6 @@
     "enabled": true
   },
   "prHourlyLimit": 20,
-  "prConcurrentLimit": 1
+  "prConcurrentLimit": 1,
+  "labels": ["renovatebot"]
 }


### PR DESCRIPTION
- Adds the label `renovatebot` to all PRs that renovate opens
- We need this label to filter by it in the GitHub Slack integration

https://issues.redhat.com/browse/RHDHPAI-1108